### PR TITLE
Added respData to error callbacks for better debuging/reporting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ Freemarker.prototype.render = function(tpl, data, done) {
     var args = [tplFile, '-C', cfgFile];
     fmpp.run(args, function getFMPPResult(err, respData) {
       if(err) {
-        return done(err);
+        return done(err,null,respData);
       }
 
       fs.readFile(tmpFile, function(err, result) {


### PR DESCRIPTION
Added the respData to the error callback so that better debugging is exposed which is really helpfull when errors occur. For example: 
' >>> ABORTED! <<<

The cause of aborting was:
FreeMarker template error: The following has evaluated to null or missing:
==> currentModel.items  [in template "components/carousel/legacy/carousel.ftl"
at line 7, column 20]'
