### PR TITLE
Scource root param

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,11 +32,15 @@ function Freemarker(settings) {
   var fmpOpts = settings.options || {};
 
   if(!settings.sourceRoot) {
-    throw new Error('Freemarker: Need sourceRoot param.')
+    if(settings.viewRoot) {
+      fmpOpts.sourceRoot = settings.viewRoot;
+    }else {
+      throw new Error('Freemarker: Need sourceRoot or viewRoot param.')
+    }
+  }else {
+    fmpOpts.sourceRoot = settings.sourceRoot;
   }
-
-  fmpOpts.sourceRoot = settings.sourceRoot;
-
+  
   if(!fmpOpts.outputRoot) {
     fmpOpts.outputRoot = os.tmpDir();
   }

--- a/index.js
+++ b/index.js
@@ -31,12 +31,12 @@ function writeTmpFileSync(data) {
 function Freemarker(settings) {
   var fmpOpts = settings.options || {};
 
-  if(!settings.viewRoot) {
-    throw new Error('Freemarker: Need viewRoot param.')
+  if(!settings.sourceRoot) {
+    throw new Error('Freemarker: Need sourceRoot param.')
   }
-  if(!fmpOpts.sourceRoot) {
-    fmpOpts.sourceRoot = settings.viewRoot;
-  }
+
+  fmpOpts.sourceRoot = settings.sourceRoot;
+
   if(!fmpOpts.outputRoot) {
     fmpOpts.outputRoot = os.tmpDir();
   }
@@ -45,7 +45,7 @@ function Freemarker(settings) {
   fmpOpts.sourceRoot = fmpOpts.sourceRoot.replace(/\\/g, '/');
   fmpOpts.outputRoot = fmpOpts.outputRoot.replace(/\\/g, '/');
 
-  this.viewRoot = settings.viewRoot;
+  this.viewRoot = settings.viewRoot || '';
   this.options = fmpOpts;
 }
 


### PR DESCRIPTION
在原使用方式上，添加一种新的方式：渲染模板时使用绝对路径。

具体为：
- 定义`settings.sourceRoot`、不定义`settings.viewRoot`
- 调用`.render()`等方法渲染模板时，第一个参数（模板路径）使用绝对路径